### PR TITLE
fix: avoid menus overflow scrolling side effect

### DIFF
--- a/apps/admin/src/layouts/sidebar/components/Menu.vue
+++ b/apps/admin/src/layouts/sidebar/components/Menu.vue
@@ -88,7 +88,7 @@ const collapsedWidth = computed<number>(() => collapsed ? 64 : 300);
 
 <template>
   <div :class="collapsed ? 'w-16' : 'w-75'" class="transition-width h-full shrink-0 flex-col overflow-hidden duration-75">
-    <NScrollbar>
+    <NScrollbar class="max-h-[calc(100vh_-_4rem)]">
       <NMenu
         v-model:value="activeMenu"
         :collapsed="collapsed"

--- a/apps/admin/src/layouts/sidebar/index.vue
+++ b/apps/admin/src/layouts/sidebar/index.vue
@@ -16,7 +16,7 @@ const sidebar = ref(null);
 <template>
   <aside
     id="sidebar"
-    class="sidebar flex flex-col"
+    class="sidebar flex flex-col h-full"
     :class="{ collapsed: isCollapse, opened: !isCollapse }"
   >
     <div ref="sidebar" class="sidebar-wrap grow flex flex-col">


### PR DESCRIPTION
### Before
![20240319114453_rec_](https://github.com/kirklin/celeris-web/assets/45714701/4d5de737-1916-4c37-bd4d-9eb5a6bd1a9f)

<hr />

### After
![20240319114533_rec_](https://github.com/kirklin/celeris-web/assets/45714701/4708c921-f97b-4bdc-8d70-b5bce5b03183)