### PR TITLE
fix: modify pageWrapper margin style to keep top, bottom, left, and right equal

### DIFF
--- a/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
+++ b/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
@@ -10,7 +10,7 @@ withDefaults(defineProps<PageWrapperProps>(), {
 
 <template>
   <div class="page-wrapper rounded-2xl w-full h-full min-h-full">
-    <NScrollbar v-if="useScrollbar" content-class="scrollbar-content" class="rounded-2xl">
+    <NScrollbar v-if="useScrollbar" class="rounded-2xl">
       <slot />
     </NScrollbar>
     <slot v-else />
@@ -28,7 +28,8 @@ withDefaults(defineProps<PageWrapperProps>(), {
   width: calc(100% + 8px);
 }
 
-.page-wrapper :deep(.scrollbar-content) {
-  padding-right: 8px;
+.page-wrapper :deep(.ca-scrollbar-container) {
+  width: calc(100% - 8px);
+  border-radius: 1em;
 }
 </style>

--- a/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
+++ b/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
@@ -10,7 +10,7 @@ withDefaults(defineProps<PageWrapperProps>(), {
 
 <template>
   <div class="page-wrapper rounded-2xl w-full h-full min-h-full">
-    <NScrollbar v-if="useScrollbar" class="rounded-2xl">
+    <NScrollbar v-if="useScrollbar" content-class="scrollbar-content" class="rounded-2xl">
       <slot />
     </NScrollbar>
     <slot v-else />
@@ -24,10 +24,11 @@ withDefaults(defineProps<PageWrapperProps>(), {
 /*
   Enhance scrollbar appearance within the pageWrapper container to maintain content visibility
 */
-.page-wrapper :deep(.ca-scrollbar-container) {
-  padding: 0 8px;
+.page-wrapper {
+  width: calc(100% + 8px);
 }
-.page-wrapper :deep(.ca-scrollbar) {
-  margin: 8px 0;
+
+.page-wrapper :deep(.scrollbar-content) {
+  padding-right: 8px;
 }
 </style>

--- a/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
+++ b/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
@@ -9,7 +9,7 @@ withDefaults(defineProps<PageWrapperProps>(), {
 </script>
 
 <template>
-  <div class="page-wrapper rounded-2xl w-full h-full min-h-full">
+  <div class="page-wrapper" :class="[{ 'scrollbar-enabled': useScrollbar }]">
     <NScrollbar v-if="useScrollbar" class="rounded-2xl">
       <slot />
     </NScrollbar>
@@ -18,18 +18,18 @@ withDefaults(defineProps<PageWrapperProps>(), {
 </template>
 
 <style scoped>
-/*
-  TODO: Explore alternative methods for styling the scrollbar within the pageWrapper component.
- */
-/*
-  Enhance scrollbar appearance within the pageWrapper container to maintain content visibility
-*/
 .page-wrapper {
+  /* Default styles for page-wrapper */
+  @apply rounded-2xl w-full h-full min-h-full;
+}
+
+.page-wrapper.scrollbar-enabled {
+  /* Styles specific to when scrollbar is enabled */
   width: calc(100% + 8px);
 }
 
-.page-wrapper :deep(.ca-scrollbar-container) {
+.page-wrapper.scrollbar-enabled :deep(.ca-scrollbar-container) {
   width: calc(100% - 8px);
-  border-radius: 1em;
+  @apply rounded-2xl;
 }
 </style>

--- a/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
+++ b/apps/admin/src/component/PageWrapper/src/PageWrapper.vue
@@ -27,4 +27,7 @@ withDefaults(defineProps<PageWrapperProps>(), {
 .page-wrapper :deep(.ca-scrollbar-container) {
   padding: 0 8px;
 }
+.page-wrapper :deep(.ca-scrollbar) {
+  margin: 8px 0;
+}
 </style>


### PR DESCRIPTION
## Proposed changes

修改pageWrapper边距样式保持上下左右边距相等
![image](https://github.com/kirklin/celeris-web/assets/47178158/73a25c2d-cf2e-42d0-9da8-452ee571a1b8)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Linked Issues

#21 
